### PR TITLE
Fix migrations environment

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -188,4 +188,7 @@
     <Folder Include="Models\Economy\Business\Driving\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="CopyLinkedContentFiles" BeforeTargets="Build">
+    <Copy SourceFiles="..\lib\CitizenFX.Server.dll" DestinationFiles="..\CitizenFX.Core.dll" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
This change causes building Core to copy ``CitizenFX.Server.dll`` to ``CitizenFX.Core.dll`` as the library must be located at that file name for EF migrations to function.